### PR TITLE
removes call to contentComplete

### DIFF
--- a/AdvancedExample/AdvancedExample/VideoViewController.m
+++ b/AdvancedExample/AdvancedExample/VideoViewController.m
@@ -150,7 +150,6 @@ typedef NS_ENUM(NSInteger, PlayButtonType) {
     self.castManager.videoVC = nil;
 
     [self.streamManager destroy];
-    [self.adsLoader contentComplete];
   }
 }
 


### PR DESCRIPTION
The call to `contentComplete` seems unnecessary given that the postRolls are already stitched into the stream. In addition, `viewWillDisappear` seems late to request postRolls. 